### PR TITLE
add buy-crypto-usdt banner

### DIFF
--- a/data/allMarketsCards/beta.json
+++ b/data/allMarketsCards/beta.json
@@ -7,6 +7,13 @@
     },
     {
       "type": "Buy_Crypto",
+      "analyticsTag": "Buy Crypto - USDT",
+      "imageURL": "https://www.delta.exchange/wp-content/uploads/2022/12/aplyne-web.png",
+      "redirectURL": "https://www.delta.exchange/app/account/buy_crypto",
+      "openInNewTab": true
+    },
+    {
+      "type": "Buy_Crypto",
       "analyticsTag": "Buy Crypto - Onmeta",
       "imageURL": "https://www.delta.exchange/wp-content/uploads/2022/11/image-14.png",
       "redirectURL": "https://www.delta.exchange/app/account/buy_crypto",
@@ -52,6 +59,13 @@
       "type": "offerTimeline",
       "analyticsTag": "Offer Timeline",
       "showWhenLogin": "preLogin"
+    },
+    {
+      "type": "Buy_Crypto",
+      "analyticsTag": "Buy Crypto - USDT",
+      "imageURL": "https://www.delta.exchange/wp-content/uploads/2022/12/alpyne-mobile.png",
+      "redirectURL": "https://www.delta.exchange/app/account/buy_crypto",
+      "openInNewTab": true
     },
     {
       "type": "Buy_Crypto",

--- a/data/allMarketsCards/devnet.json
+++ b/data/allMarketsCards/devnet.json
@@ -2,6 +2,13 @@
   "desktop": [
     {
       "type": "Buy_Crypto",
+      "analyticsTag": "Buy Crypto - USDT",
+      "imageURL": "https://www.delta.exchange/wp-content/uploads/2022/12/aplyne-web.png",
+      "redirectURL": "https://www.delta.exchange/app/account/buy_crypto",
+      "openInNewTab": true
+    },
+    {
+      "type": "Buy_Crypto",
       "analyticsTag": "Buy Crypto - Onmeta",
       "imageURL": "https://www.delta.exchange/wp-content/uploads/2022/11/image-14.png",
       "redirectURL": "https://www.delta.exchange/app/account/buy_crypto",
@@ -55,6 +62,13 @@
     }
   ],
   "mobile": [
+    {
+      "type": "Buy_Crypto",
+      "analyticsTag": "Buy Crypto - USDT",
+      "imageURL": "https://www.delta.exchange/wp-content/uploads/2022/12/alpyne-mobile.png",
+      "redirectURL": "https://www.delta.exchange/app/account/buy_crypto",
+      "openInNewTab": true
+    },
     {
       "type": "Buy_Crypto",
       "analyticsTag": "Buy Crypto - Onmeta",

--- a/data/allMarketsCards/prod.json
+++ b/data/allMarketsCards/prod.json
@@ -7,6 +7,13 @@
     },
     {
       "type": "Buy_Crypto",
+      "analyticsTag": "Buy Crypto - USDT",
+      "imageURL": "https://www.delta.exchange/wp-content/uploads/2022/12/aplyne-web.png",
+      "redirectURL": "https://www.delta.exchange/app/account/buy_crypto",
+      "openInNewTab": true
+    },
+    {
+      "type": "Buy_Crypto",
       "analyticsTag": "Buy Crypto - Onmeta",
       "imageURL": "https://www.delta.exchange/wp-content/uploads/2022/11/image-14.png",
       "redirectURL": "https://www.delta.exchange/app/account/buy_crypto",
@@ -52,6 +59,13 @@
       "type": "offerTimeline",
       "analyticsTag": "Offer Timeline",
       "showWhenLogin": "preLogin"
+    },
+    {
+      "type": "Buy_Crypto",
+      "analyticsTag": "Buy Crypto - USDT",
+      "imageURL": "https://www.delta.exchange/wp-content/uploads/2022/12/alpyne-mobile.png",
+      "redirectURL": "https://www.delta.exchange/app/account/buy_crypto",
+      "openInNewTab": true
     },
     {
       "type": "Buy_Crypto",


### PR DESCRIPTION
### Description
Add Buy crypto USDT Banners. They will redirect to buy_crypto page.

Banner Links:
Desktop: https://www.delta.exchange/wp-content/uploads/2022/12/aplyne-web.png
Mobile: https://www.delta.exchange/wp-content/uploads/2022/12/alpyne-mobile.png